### PR TITLE
contributors-add-own-blog-posts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require maintainer review for blog content and related assets.
+_posts/ @DrGLDavidson
+images/ @DrGLDavidson

--- a/.github/ISSUE_TEMPLATE/blog-post.yml
+++ b/.github/ISSUE_TEMPLATE/blog-post.yml
@@ -1,0 +1,72 @@
+name: Blog post submission
+description: Submit a blog post draft without editing repository files directly.
+title: "Blog post: "
+labels:
+  - blog
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form if you want a maintainer to help turn your draft into a pull request.
+
+  - type: input
+    id: title
+    attributes:
+      label: Post title
+      description: The title that should appear on the blog.
+      placeholder: Example post title
+    validations:
+      required: true
+
+  - type: input
+    id: author
+    attributes:
+      label: Author slug
+      description: Use a member slug from the _members folder when possible.
+      placeholder: gabrielle-davidson
+    validations:
+      required: true
+
+  - type: input
+    id: tags
+    attributes:
+      label: Tags
+      description: Comma-separated tags.
+      placeholder: news, media
+    validations:
+      required: true
+
+  - type: textarea
+    id: excerpt
+    attributes:
+      label: Short excerpt
+      description: One or two sentences for the blog listing.
+      placeholder: Add a short summary here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: body
+    attributes:
+      label: Post body
+      description: Markdown is supported.
+      placeholder: Write the full post here.
+    validations:
+      required: true
+
+  - type: input
+    id: image
+    attributes:
+      label: Image path
+      description: Optional repository path such as images/example.jpg.
+      placeholder: images/example.jpg
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for the maintainer
+      description: Add links, credits, deadlines, or anything else that matters.
+    validations:
+      required: false

--- a/.github/blog-post-template.md
+++ b/.github/blog-post-template.md
@@ -1,0 +1,16 @@
+---
+title: Add your post title here
+author: your-member-slug
+tags:
+  - news
+image: images/your-image-file.jpg
+---
+
+<!-- excerpt start -->Add a 1 to 2 sentence summary here.<!-- excerpt end -->
+
+Write the main body of the blog post here.
+
+{%
+  include figure.html
+  image="images/your-image-file.jpg"
+%}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,16 @@
+## Summary
 
+Describe the blog post or content change in 1 to 3 sentences.
+
+## Checklist
+
+- [ ] I added or updated a post in `_posts`.
+- [ ] The post filename uses `YYYY-MM-DD-short-title.md`.
+- [ ] The post includes `title`, `author`, and `tags` in front matter.
+- [ ] The post includes excerpt markers for the blog index.
+- [ ] Any referenced images were added to the repository.
+- [ ] I checked the pull request preview, if available.
+
+## Notes for reviewer
+
+Add anything the reviewer should verify before merge.

--- a/.github/workflows/validate-blog-posts.yaml
+++ b/.github/workflows/validate-blog-posts.yaml
@@ -1,0 +1,121 @@
+name: validate-blog-posts
+run-name: validate blog post pull request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    paths:
+      - "_posts/**"
+      - "images/**"
+      - ".github/blog-post-template.md"
+      - "CONTRIBUTING.md"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-blog-posts:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate changed blog posts
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+
+          python <<'PY'
+          import os
+          import re
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          diff_result = subprocess.run(
+              ["git", "diff", "--name-only", f"origin/{os.environ['BASE_REF']}...HEAD"],
+              check=True,
+              capture_output=True,
+              text=True,
+          )
+
+          changed_files = [
+              line.strip()
+              for line in diff_result.stdout.splitlines()
+              if line.strip()
+          ]
+          changed_posts = [
+              path for path in changed_files
+              if path.startswith("_posts/") and path.endswith(".md")
+          ]
+
+          if not changed_posts:
+              print("No changed blog post files found in this pull request.")
+              sys.exit(0)
+
+          filename_pattern = re.compile(r"^_posts/\d{4}-\d{2}-\d{2}-[a-z0-9-]+\.md$")
+          required_fields = ("title", "author", "tags")
+          errors = []
+
+          for post_path in changed_posts:
+              path = Path(post_path)
+
+              if not filename_pattern.match(post_path):
+                  errors.append(
+                      f"{post_path}: filename must match _posts/YYYY-MM-DD-short-title.md"
+                  )
+
+              if not path.exists():
+                  errors.append(f"{post_path}: file does not exist in the checked out branch")
+                  continue
+
+              text = path.read_text(encoding="utf-8")
+              front_matter_match = re.match(
+                  r"^---\r?\n(.*?)\r?\n---\r?\n(.*)$",
+                  text,
+                  re.DOTALL,
+              )
+              if not front_matter_match:
+                  errors.append(f"{post_path}: front matter must be wrapped in --- delimiters")
+                  continue
+
+              front_matter = front_matter_match.group(1)
+              body = front_matter_match.group(2)
+
+              for field in required_fields:
+                  if not re.search(rf"(?m)^{field}:\s*(\S.*)?$", front_matter):
+                      errors.append(f"{post_path}: missing required front matter field '{field}'")
+
+              has_excerpt_start = "<!-- excerpt start -->" in body
+              has_excerpt_end = "<!-- excerpt end -->" in body
+              if not has_excerpt_start or not has_excerpt_end:
+                  errors.append(
+                      f"{post_path}: excerpt markers '<!-- excerpt start -->' and '<!-- excerpt end -->' are required"
+                  )
+
+              image_match = re.search(r"(?m)^image:\s*([^\n]+)$", front_matter)
+              if image_match:
+                  image_path = image_match.group(1).strip().strip("\"'")
+                  if image_path and not Path(image_path).exists():
+                      errors.append(
+                          f"{post_path}: image path '{image_path}' does not exist in the repository"
+                      )
+
+          if errors:
+              print("Blog post validation failed:\n")
+              for error in errors:
+                  print(f"- {error}")
+              sys.exit(1)
+
+          print("Blog post validation passed for changed post files:")
+          for post_path in changed_posts:
+              print(f"- {post_path}")
+          PY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+This site accepts blog post contributions through GitHub pull requests.
+
+## Submit a blog post in GitHub
+
+If you are comfortable using GitHub, the easiest route is to open a pull request with a new file in [_posts](./_posts).
+
+1. Open [.github/blog-post-template.md](./.github/blog-post-template.md).
+2. Copy the template contents.
+3. Create a new branch in GitHub.
+4. Add a new file in [_posts](./_posts) named `YYYY-MM-DD-short-title.md`.
+5. Paste the template and fill in the details.
+6. If your post uses an image, upload it to [images](./images) in the same branch.
+7. Open a pull request.
+
+All blog post pull requests are reviewed before merge.
+
+## Blog post requirements
+
+- The file must live in [_posts](./_posts).
+- The filename must use the pattern `YYYY-MM-DD-short-title.md`.
+- Front matter must include `title`, `author`, and `tags`.
+- `author` should match a member slug from [_members](./_members) when possible, for example `gabrielle-davidson`.
+- Add an excerpt between `<!-- excerpt start -->` and `<!-- excerpt end -->` so the blog index shows a clean summary.
+- If you reference an image in front matter, the image file must be committed to the repository.
+
+## Submit a draft without editing files
+
+If you do not want to edit Markdown directly, open a GitHub issue using the Blog Post Submission form and provide the text there. A maintainer can turn that into a pull request for review.
+
+## Review and merge policy
+
+- Contributors should open pull requests against `main`.
+- Pull requests for blog posts are intended for maintainer review.
+- Repository owners should enable branch protection on `main` and require at least one approving review before merge.
+- Repository owners should keep auto-merge disabled unless they explicitly want to use it.

--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@
   Visit **[drgldavidson.github.io/ACMEresearch](https://drgldavidson.github.io/ACMEresearch)** 🚀
 
   _Built with [Lab Website Template](https://greene-lab.gitbook.io/lab-website-template-docs)_
+
+## Contributing blog posts
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the GitHub pull request workflow and the blog post template.


### PR DESCRIPTION
Added a contributor-friendly blog submission workflow for the site. This includes guidance for submitting blog posts through GitHub pull requests, a reusable blog post template, a structured issue form for non-technical contributors, a PR checklist, CODEOWNERS rules to route blog and image changes for maintainer review, and a validation workflow that checks post filenames, required front matter, excerpt markers, and referenced images. This setup is intended to keep blog contributions easy to submit while ensuring posts are reviewed before merge.


